### PR TITLE
[SHOT-3302] Remove recursive transformation in scene_operations.py during Scene Breakdown Update

### DIFF
--- a/hooks/tk-multi-breakdown/basic/scene_operations.py
+++ b/hooks/tk-multi-breakdown/basic/scene_operations.py
@@ -102,13 +102,16 @@ class SceneOperation(HookClass):
 
         self._apply_materials(old_node, new_node, materials)
 
-        for i in range(0, old_node.getNChildren()):
-            for j in range(0, new_node.getNChildren()):
-                if old_node.getChild(i).getName() == new_node.getChild(j).getName():
-                    self._apply_transformations(
-                        old_node.getChild(i), new_node.getChild(j), materials
-                    )
-                    break
+        old_node_child = old_node.getChild(0)
+        old_node_child_name = old_node_child.getName()
+
+        for i in range(0, new_node.getNChildren()):
+            new_node_child = new_node.getChild(i)
+            new_node_child_name = new_node_child.getName()
+
+            if old_node_child_name == new_node_child_name:
+                self._apply_transformations(old_node_child, new_node_child, materials)
+                break
 
     def _apply_materials(self, old_node, new_node, materials):
         """


### PR DESCRIPTION
In apply transformations mehod use only the first child of the old node for every new node children.