### PR TITLE
Clean up publish hooks

### DIFF
--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -342,15 +342,7 @@ def _get_save_as_action():
     """
 
     engine = sgtk.platform.current_engine()
-
-    # default save callback
     callback = engine.open_save_as_dialog
-
-    # if workfiles2 is configured, use that for file save
-    if "tk-multi-workfiles2" in engine.apps:
-        app = engine.apps["tk-multi-workfiles2"]
-        if hasattr(app, "show_file_save_dlg"):
-            callback = app.show_file_save_dlg
 
     return {
         "action_button": {

--- a/hooks/tk-multi-publish2/basic/start_version_control.py
+++ b/hooks/tk-multi-publish2/basic/start_version_control.py
@@ -274,15 +274,7 @@ def _get_save_as_action():
     """
 
     engine = sgtk.platform.current_engine()
-
-    # default save callback
     callback = engine.open_save_as_dialog
-
-    # if workfiles2 is configured, use that for file save
-    if "tk-multi-workfiles2" in engine.apps:
-        app = engine.apps["tk-multi-workfiles2"]
-        if hasattr(app, "show_file_save_dlg"):
-            callback = app.show_file_save_dlg
 
     return {
         "action_button": {


### PR DESCRIPTION
We no longer need to check for the Workfiles2 save dialog from the publish hook, since the engine now does this for us in the open_save_as_dialog (changes made for SHOT-3502).