### PR TITLE
[SHOT-3580] Fix VRED process hanging

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -286,23 +286,28 @@ class VREDEngine(sgtk.platform.Engine):
                 widget.show()
                 return widget
 
-        # As VRED doesn't have a method inside it's API to dock widget, we need to create one by hand,
-        # parent it to the main window and display the app widget inside
-        parent = self._get_dialog_parent()
+        if not self.has_ui:
+            self.log_error(
+                "Sorry, this environment does not support UI display! Cannot show "
+                "the requested window '{}'.".format(title)
+            )
+            return None
 
-        dock_widget = QtGui.QDockWidget(title, parent=parent)
+        # Create a dialog with the panel widget so that the TankQDialog class will take care of
+        # cleaning up the widget.
+        dialog, widget = self._create_dialog_with_widget(
+            title, bundle, widget_class, *args, **kwargs
+        )
+
+        # VRED does not have a Python PI method to dock a widget, so we need to create a dock widget
+        # and dock it to the VRED main window.
+        dock_widget = QtGui.QDockWidget(title)
         dock_widget.setObjectName(panel_id)
-
-        widget_instance = widget_class(*args, **kwargs)
-        widget_instance.setParent(dock_widget)
-        self._apply_external_styleshet(bundle, widget_instance)
-
-        dock_widget.setWidget(widget_instance)
-        dock_widget.show()
-
+        dock_widget.setWidget(dialog)
+        parent = self._get_dialog_parent()
         parent.addDockWidget(QtCore.Qt.RightDockWidgetArea, dock_widget)
 
-        return widget_instance
+        return dock_widget
 
     #####################################################################################
     # VRED File IO

--- a/plugins/Shotgun/vrShotgun.py
+++ b/plugins/Shotgun/vrShotgun.py
@@ -16,6 +16,9 @@ sgtk.LogManager().initialize_base_file_handler("tk-vred")
 logger = sgtk.LogManager.get_logger(__name__)
 vrShotgun_form, vrShotgun_base = uiTools.loadUiType("vrShotgunGUI.ui")
 
+# The vrShotgun plugin module instance
+shotgun = None
+
 
 class vrShotgun(vrShotgun_form, vrShotgun_base):
     context = None
@@ -98,6 +101,15 @@ class vrShotgun(vrShotgun_form, vrShotgun_base):
             self.parentWidget().parentWidget().adjustSize()
 
         return super(vrShotgun, self).resizeEvent(event)
+
+
+def onDestroyVREDScriptPlugin():
+    """
+    onDestroyVREDScriptPlugin() is called before this plugin is destroyed. In this
+    plugin we want to destroy the VRED engine, which will handle any necessary clean up.
+    """
+    if shotgun and shotgun.engine:
+        shotgun.engine.destroy_engine()
 
 
 try:


### PR DESCRIPTION
* Use the VRED plugin callback on before destroy, onDestroyVREDScriptPlugin, to envoke the VRED engine destroy method to ensure proper clean up on shutdown.