### PR TITLE
Indent for windows specific code block

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -188,21 +188,21 @@ class VREDLauncher(SoftwareLauncher):
                 self.logger
             )
 
-        for install_paths in install_paths_dicts:
-            executable_version = self._map_version_year(install_paths["version"])
-            executable_path = install_paths["path"]
-            launcher_name = install_paths["_name"]
-            icon_file = self._icon_from_executable(launcher_name)
+            for install_paths in install_paths_dicts:
+                executable_version = self._map_version_year(install_paths["version"])
+                executable_path = install_paths["path"]
+                launcher_name = install_paths["_name"]
+                icon_file = self._icon_from_executable(launcher_name)
 
-            # Create The actual SoftwareVersions
-            sw_versions.append(
-                SoftwareVersion(
-                    executable_version,
-                    launcher_name,
-                    executable_path,
-                    icon_file,
+                # Create The actual SoftwareVersions
+                sw_versions.append(
+                    SoftwareVersion(
+                        executable_version,
+                        launcher_name,
+                        executable_path,
+                        icon_file,
+                    )
                 )
-            )
 
         return sw_versions
 


### PR DESCRIPTION
* Fixes error 'install_paths_dict' referenced before being defined, if `is_windows()` returns False.

This is not a major issue since at the moment, tk-vred is meant to only be used on Windows.