### PR TITLE
[SHOT-3906] Fixed menu favourites property.

### DIFF
--- a/python/tk_vred/menu_generation.py
+++ b/python/tk_vred/menu_generation.py
@@ -143,12 +143,13 @@ class VREDMenuGenerator(object):
         """
 
         if self._root_menu is not None:
-            self._engine.logger.debug("{}: Clean up menu".format(self))
+            self._engine.logger.debug("{}: Clean up root menu".format(self))
 
             self._root_menu.clean()
             self._root_menu = None
 
         if self._menu_favourites is not None:
+            self._engine.logger.debug("{}: Clean up favourites menu".format(self))
             self._menu_favourites = None
 
     def _create_context_menu(self):

--- a/python/tk_vred/menu_generation.py
+++ b/python/tk_vred/menu_generation.py
@@ -39,8 +39,9 @@ class VREDMenuGenerator(object):
         The menu favourites, in sorted order by name.
         """
 
-        self._menu_favourites = self._engine.get_setting("menu_favourites", [])
-        self._menu_favourites.sort(key=lambda f: f["name"])
+        if self._menu_favourites is None:
+            self._menu_favourites = self._engine.get_setting("menu_favourites", [])
+            self._menu_favourites.sort(key=lambda f: f["name"])
 
         return self._menu_favourites
 
@@ -145,6 +146,9 @@ class VREDMenuGenerator(object):
 
             self._root_menu.clean()
             self._root_menu = None
+
+        if self._menu_favourites is not None:
+            self._menu_favourites = None
 
     def _create_context_menu(self):
         """

--- a/python/tk_vred/menu_generation.py
+++ b/python/tk_vred/menu_generation.py
@@ -39,9 +39,8 @@ class VREDMenuGenerator(object):
         The menu favourites, in sorted order by name.
         """
 
-        if self._menu_favourites is None:
-            self._menu_favourites = self._engine.get_setting("menu_favourites", [])
-            self._menu_favourites.sort(key=lambda f: f["name"])
+        self._menu_favourites = self._engine.get_setting("menu_favourites", [])
+        self._menu_favourites.sort(key=lambda f: f["name"])
 
         return self._menu_favourites
 

--- a/python/tk_vred/menu_generation.py
+++ b/python/tk_vred/menu_generation.py
@@ -138,7 +138,8 @@ class VREDMenuGenerator(object):
 
     def clean_menu(self):
         """
-        Remove ShotGrid root menu in VRED, if it exists.
+        Remove ShotGrid root menu in VRED, if it exists and
+        clear the menu_favourites property.
         """
 
         if self._root_menu is not None:


### PR DESCRIPTION
The favourites had an entry from the Project context so was not _None_ and thus would not re-build properly.
It should be safe to re-build this each time, Stacey? I don't see why not.
Thanks!