### PR TITLE
SHOT-3905: 3D Version config setting editable in Publisher plugin UI

### DIFF
--- a/hooks/tk-multi-publish2/basic/upload_session_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_session_version.py
@@ -109,43 +109,6 @@ class UploadVersionPlugin(HookBaseClass):
         """
         return ["vred.session"]
 
-    @property
-    def description(self):
-        """
-        Verbose, multi-line description of what the plugin does (:class:`str`).
-
-        The string can contain html for formatting for display in the UI (any
-        html tags supported by Qt's rich text engine).
-
-        The description is displayed via the plugin's default
-        :meth:`create_settings_widget` implementation, as shown in the image
-        below:
-
-        .. image:: ./resources/plugin_description.png
-
-        |
-
-        A simple implementation example:
-
-        .. code-block:: python
-
-            @property
-            def description(self):
-
-                return '''
-                Creates a publish in Shotgun.
-
-                A <b>Publish</b> entry will be created in Shotgun which will
-                include a reference to the file's path on disk. Other users will
-                be able to access the published file via the
-                <b><a href='%s'>Loader</a></b> so long as they have access to
-                the file's location on disk.
-                ''' % (loader_url,)
-
-        """
-
-        return self.VERSION_TYPE_DESCRIPTIONS[self.VERSION_TYPE_2D]
-
     def accept(self, settings, item):
         """
         Method called by the publisher to determine if an item is of any

--- a/hooks/tk-multi-publish2/basic/upload_session_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_session_version.py
@@ -22,6 +22,30 @@ class UploadVersionPlugin(HookBaseClass):
     Plugin for sending quicktimes and images to ShotGrid for review.
     """
 
+    # Version Type string constants
+    VERSION_TYPE_2D = "2D Version"
+    VERSION_TYPE_3D = "3D Version"
+
+    # Version Type Options
+    VERSION_TYPE_OPTIONS = [
+        VERSION_TYPE_2D,
+        VERSION_TYPE_3D,
+    ]
+
+    # Descriptions for Version Types
+    VERSION_TYPE_DESCRIPTIONS = {
+        VERSION_TYPE_2D: """
+                Create a Version in ShotGrid for Review.<br/><br/>
+                A 2D Version (image or video representation of your file/scene) will be created in ShotGrid.
+                This Version can then be reviewed via ShotGrid's many review apps.
+            """,
+        VERSION_TYPE_3D: """
+                Create a Version in ShotGrid for Review.<br/><br/>
+                A 3D Version (LMV translation of your file/scene's geometry) will be created in ShotGrid.
+                This Version can then be reviewed via ShotGrid's many review apps.
+            """,
+    }
+
     @property
     def icon(self):
         """
@@ -58,10 +82,13 @@ class UploadVersionPlugin(HookBaseClass):
 
         # settings specific to this class
         upload_version_settings = {
-            "3D Version": {
-                "type": "bool",
-                "default": True,
-                "description": "Generate a 3D Version instead of a 2D one?",
+            "Version Type": {
+                "type": "str",
+                "default": self.VERSION_TYPE_OPTIONS[0],
+                "description": "Generate a {options} or {last_option} Version".format(
+                    options=", ".join(self.VERSION_TYPE_OPTIONS[:-1]),
+                    last_option=self.VERSION_TYPE_OPTIONS[-1],
+                ),
             },
             "Upload": {
                 "type": "bool",
@@ -131,6 +158,30 @@ class UploadVersionPlugin(HookBaseClass):
         :returns: True if item is valid, False otherwise.
         """
 
+        # Validate fails if the Version Type is not supported
+        version_type = settings.get("Version Type").value
+        if version_type not in self.VERSION_TYPE_OPTIONS:
+            self.logger.error("Unsupported Version Type '{}'".format(version_type))
+            return False
+
+        # Check the site pref for 3D Review enabled. Provide warning messages if the user is
+        # attempting to create a 3D Version but may not have 3D Review enabled on their site, but
+        # do not block the user from publishing.
+        if version_type == self.VERSION_TYPE_3D:
+            is_3d_viewer_enabled = self._is_3d_viewer_enabled()
+            if is_3d_viewer_enabled is None:
+                self.logger.warning(
+                    "Failed to check if 3D Review is enabled for your site."
+                )
+                self.logger.warning(
+                    "Please contact Autodesk support to access your site preference for 3D Review or use the 2D Version publish option instead."
+                )
+            elif not is_3d_viewer_enabled:
+                self.logger.warning("Your site does not have 3D Review enabled.")
+                self.logger.warning(
+                    "Please contact Autodesk support to have 3D Review enabled on your ShotGrid site or use the 2D Version publish option instead."
+                )
+
         framework_lmv = self.load_framework("tk-framework-lmv_v0.x.x")
         if not framework_lmv:
             self.logger.error("Could not run LMV translation: missing ATF framework")
@@ -159,8 +210,11 @@ class UploadVersionPlugin(HookBaseClass):
         # create the Version in Shotgun
         super(UploadVersionPlugin, self).publish(settings, item)
 
-        # generate the Version content: LMV file or simple 2D thumbnail
-        if settings.get("3D Version").value is True:
+        # Get the version type to create
+        version_type = settings.get("Version Type").value
+
+        # generate the Version content: LMV file (for 3D) or simple 2D thumbnail
+        if version_type == self.VERSION_TYPE_3D:
             self.logger.debug("Creating LMV files from source file")
             # translate the file to lmv and upload the corresponding package to the Version
             (
@@ -191,7 +245,7 @@ class UploadVersionPlugin(HookBaseClass):
             self.logger.debug("Deleting temporary folder")
             shutil.rmtree(output_directory)
 
-        else:
+        elif version_type == self.VERSION_TYPE_2D:
             thumbnail_path = item.get_thumbnail_as_path()
             if not thumbnail_path:
                 self.logger.debug(
@@ -209,6 +263,262 @@ class UploadVersionPlugin(HookBaseClass):
                 path=thumbnail_path,
                 field_name="sg_uploaded_movie",
             )
+        else:
+            raise NotImplementedError(
+                "Failed to generate thumbnail for Version Type '{}'".format(
+                    version_type
+                )
+            )
+
+    ############################################################################
+    # Methods for creating/displaying custom plugin interface
+
+    def create_settings_widget(self, parent, items=None):
+        """
+        Creates a Qt widget, for the supplied parent widget (a container widget
+        on the right side of the publish UI).
+
+        :param parent: The parent to use for the widget being created.
+        :param items: A list of PublishItems the selected publish tasks are parented to.
+        :return: A QtGui.QWidget or subclass that displays information about
+            the plugin and/or editable widgets for modifying the plugin's
+            settings.
+        """
+
+        # defer Qt-related imports
+        from sgtk.platform.qt import QtCore, QtGui
+
+        # The main widget
+        widget = QtGui.QWidget(parent)
+        widget_layout = QtGui.QVBoxLayout()
+
+        # create a group box to display the description
+        description_group_box = QtGui.QGroupBox(widget)
+        description_group_box.setTitle("Description:")
+
+        # Defer setting the description text, this will be updated when
+        # the version type combobox value is changed
+        description_label = QtGui.QLabel()
+        description_label.setWordWrap(True)
+        description_label.setOpenExternalLinks(True)
+        description_label.setTextFormat(QtCore.Qt.RichText)
+
+        # create the layout to use within the group box
+        description_layout = QtGui.QVBoxLayout()
+        description_layout.addWidget(description_label)
+        description_layout.addStretch()
+        description_group_box.setLayout(description_layout)
+
+        # Add a combobox to edit the version type option
+        version_type_combobox = QtGui.QComboBox(widget)
+        version_type_combobox.setAccessibleName("Version type selection dropdown")
+        version_type_combobox.addItems(self.VERSION_TYPE_OPTIONS)
+        # Hook up the signal/slot to update the description according to the current version type
+        version_type_combobox.currentIndexChanged.connect(
+            lambda index: self._on_version_type_changed(
+                version_type_combobox.currentText(), description_label
+            )
+        )
+
+        # Add all the minor widgets to the main widget
+        widget_layout.addWidget(description_group_box)
+        widget_layout.addWidget(version_type_combobox)
+        widget.setLayout(widget_layout)
+
+        # Set the widget property to store the combobox to access in get_ui_settings and set_ui_settings
+        widget.setProperty("description_label", description_label)
+        widget.setProperty("version_type_combobox", version_type_combobox)
+
+        return widget
+
+    def get_ui_settings(self, widget, items=None):
+        """
+        This method is required to be defined in order for the custom UI to show up in the app.
+
+        Invoked by the Publisher when the selection changes. This method gathers the settings
+        on the previously selected task, so that they can be later used to repopulate the
+        custom UI if the task gets selected again. They will also be passed to the accept, validate,
+        publish and finalize methods, so that the settings can be used to drive the publish process.
+
+        The widget argument is the widget that was previously created by
+        `create_settings_widget`.
+
+        The method returns a dictionary, where the key is the name of a
+        setting that should be updated and the value is the new value of that
+        setting. Note that it is up to you how you want to store the UI's state as
+        settings and you don't have to necessarily to return all the values from
+        the UI. This is to allow the publisher to update a subset of settings
+        when multiple tasks have been selected.
+
+        Example::
+
+            {
+                 "setting_a": "/path/to/a/file"
+            }
+
+        :param widget: The widget that was created by `create_settings_widget`
+        """
+
+        ui_settings = {}
+
+        # Get the Version Type settings value from the UI combobox
+        version_type_combobox = widget.property("version_type_combobox")
+        if version_type_combobox:
+            version_type_index = version_type_combobox.currentIndex()
+            # if version_type_index >= 0 and version_type_index < len(self.VERSION_TYPE_OPTIONS):
+            if 0 <= version_type_index < len(self.VERSION_TYPE_OPTIONS):
+                self.VERSION_TYPE_OPTIONS[version_type_index]
+                ui_settings["Version Type"] = self.VERSION_TYPE_OPTIONS[
+                    version_type_index
+                ]
+            else:
+                self.logger.debug(
+                    "Invalid Version Type index {}".format(version_type_index)
+                )
+
+        return ui_settings
+
+    def set_ui_settings(self, widget, settings, items=None):
+        """
+        This method is required to be defined in order for the custom UI to show up in the app.
+
+        Allows the custom UI to populate its fields with the settings from the
+        currently selected tasks.
+
+        The widget is the widget created and returned by
+        `create_settings_widget`.
+
+        A list of settings dictionaries are supplied representing the current
+        values of the settings for selected tasks. The settings dictionaries
+        correspond to the dictionaries returned by the settings property of the
+        hook.
+
+        Example::
+
+            settings = [
+            {
+                 "seeting_a": "/path/to/a/file"
+                 "setting_b": False
+            },
+            {
+                 "setting_a": "/path/to/a/file"
+                 "setting_b": False
+            }]
+
+        The default values for the settings will be the ones specified in the
+        environment file. Each task has its own copy of the settings.
+
+        When invoked with multiple settings dictionaries, it is the
+        responsibility of the custom UI to decide how to display the
+        information. If you do not wish to implement the editing of multiple
+        tasks at the same time, you can raise a ``NotImplementedError`` when
+        there is more than one item in the list and the publisher will inform
+        the user than only one task of that type can be edited at a time.
+
+        :param widget: The widget that was created by `create_settings_widget`.
+        :param settings: a list of dictionaries of settings for each selected
+            task.
+        :param items: A list of PublishItems the selected publish tasks are parented to.
+        """
+
+        if not settings:
+            return
+
+        if len(settings) > 1:
+            raise NotImplementedError
+
+        version_type_combobox = widget.property("version_type_combobox")
+        if not version_type_combobox:
+            self.logger.debug(
+                "Failed to retrieve Version Type combobox to set custom UI"
+            )
+            return
+
+        description_label = widget.property("description_label")
+        if not description_label:
+            self.logger.debug(
+                "Failed to retrieve Version Type combobox to set custom UI"
+            )
+
+        # Get the default setting for version type
+        default_value = self.settings.get("Version Type", {}).get(
+            "default", self.VERSION_TYPE_OPTIONS[0]
+        )
+
+        # Get the version type value from the settings, and set the combobox accordingly
+        version_type_value = settings[0].get("Version Type", default_value)
+        version_type_index = max(self.VERSION_TYPE_OPTIONS.index(version_type_value), 0)
+        # Set the version type combobox
+        current_version_index = version_type_combobox.currentIndex()
+        if current_version_index == version_type_index:
+            # Combobox already has the correct verstion type - manually trigger the 'currentIndexChanged'
+            # slot to update the description label based on the version
+            self._on_version_type_changed(version_type_value, description_label)
+        else:
+            version_type_combobox.setCurrentIndex(version_type_index)
+
+    def _on_version_type_changed(self, version_type, description_label):
+        """
+        Slot called when the Version Type combobox selector index changes.
+
+        Update the description based on the current Version Type.
+
+        :param version_type: The current Version Type.
+        :type version_type: str
+        :param description_label: The label widget to set the description on
+        :type description_label: QLabel
+        """
+
+        if not description_label:
+            return
+
+        note = ""
+        if version_type == self.VERSION_TYPE_3D:
+            is_3d_viewer_enabled = self._is_3d_viewer_enabled()
+
+            if is_3d_viewer_enabled is None:
+                note = """
+                    <br/><br/>
+                    <b>NOTE:</b>
+                    <br/>
+                    <b>
+                        Failed to check if 3D Review is enabled for your site.
+                    <br/>
+                        You may create a 3D Version for review, but if 3D Review is not enabled,
+                        you will see an error message 'No web playable media available' when trying to open the Version with the Media viewer.
+                    </b>
+                    <br/><br/>
+                    <b>
+                        Please contact Autodesk support to access your site preference for 3D Review or use the 2D Version publish option instead.
+                    </b>
+                """
+            elif not is_3d_viewer_enabled:
+                note = """
+                    <br/><br/>
+                    <b>NOTE:</b>
+                    <br/>
+                    <b>
+                       Your site does not have 3D Review enabled.
+                        <br/>
+                       You may create a 3D Version for review, but until your site has 3D Review enabled,
+                       you will see an error message 'No web playable media available' when trying to open the Version with the Media viewer.
+                    </b>
+                    <br/><br/>
+                    <b>
+                        Please contact Autodesk support to have 3D Review enabled on your ShotGrid site or use the 2D Version publish option instead.
+                    </b>
+                """
+
+        text = "{description}{note}".format(
+            description=self.VERSION_TYPE_DESCRIPTIONS.get(
+                version_type, self.description
+            ),
+            note=note,
+        )
+        description_label.setText(text)
+
+    ############################################################################
+    # Protected functions
 
     def _translate_file_to_lmv(self, item):
         """
@@ -253,3 +563,27 @@ class UploadVersionPlugin(HookBaseClass):
             )
 
         return package_path, thumbnail_path, lmv_translator.output_directory
+
+    def _is_3d_viewer_enabled(self):
+        """
+        Look up the ShotGrid site preference to check if the 3D Viewer is enabled. Return True
+        if the 3D Viewer is enabled, False if it is disabled, or None if the 3D Viewer Enabled
+        site pref could not be accessed.
+
+        If the ShotGrid API returns an empty dictionary, the hidden site preference could not be
+        accessed. Ensure that the hidden site preference "API hidden allowed list of preferences"
+        contains the "enable_3d_viewer" in its list.
+
+        :return: True if the 3D Viewer is enabled for the ShotGrid site, False if it is disabled,
+                 or None if the 3D Viewer site pref could not be accessed.
+        :rtype: bool
+        """
+
+        enable_3d_viewer_pref = "enable_3d_viewer"
+        prefs = self.parent.shotgun.preferences_read(prefs=[enable_3d_viewer_pref])
+
+        if not prefs:
+            # The 'enable_3d_viewer' site pref could not be accessed
+            return None
+
+        return prefs[enable_3d_viewer_pref]

--- a/hooks/tk-multi-publish2/basic/upload_session_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_session_version.py
@@ -52,10 +52,6 @@ class UploadVersionPlugin(HookBaseClass):
         Path to an png icon on disk
         """
 
-        if hasattr(self, "plugin_icon"):
-            return self.plugin_icon
-
-        # look for icon one level up from this hook's folder in "icons" folder
         return os.path.join(self.disk_location, os.pardir, "icons", "review.png")
 
     @property
@@ -138,11 +134,6 @@ class UploadVersionPlugin(HookBaseClass):
 
         :returns: dictionary with boolean keys accepted, required and enabled
         """
-
-        if settings.get("3D Version").value is True:
-            self.plugin_icon = os.path.join(
-                self.disk_location, os.pardir, "icons", "3d_model.png"
-            )
 
         return {"accepted": True, "checked": True}
 

--- a/hooks/tk-multi-publish2/basic/upload_session_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_session_version.py
@@ -301,252 +301,250 @@ class UploadVersionPlugin(HookBaseClass):
     ############################################################################
     # Methods for creating/displaying custom plugin interface
     #
-    # Uncomment this to introduce custom UI to toggle between 2D/3D Version
-    # creation for review
 
-    # def create_settings_widget(self, parent, items=None):
-    #     """
-    #     Creates a Qt widget, for the supplied parent widget (a container widget
-    #     on the right side of the publish UI).
+    def create_settings_widget(self, parent, items=None):
+        """
+        Creates a Qt widget, for the supplied parent widget (a container widget
+        on the right side of the publish UI).
 
-    #     :param parent: The parent to use for the widget being created.
-    #     :param items: A list of PublishItems the selected publish tasks are parented to.
-    #     :return: A QtGui.QWidget or subclass that displays information about
-    #         the plugin and/or editable widgets for modifying the plugin's
-    #         settings.
-    #     """
+        :param parent: The parent to use for the widget being created.
+        :param items: A list of PublishItems the selected publish tasks are parented to.
+        :return: A QtGui.QWidget or subclass that displays information about
+            the plugin and/or editable widgets for modifying the plugin's
+            settings.
+        """
 
-    #     # defer Qt-related imports
-    #     from sgtk.platform.qt import QtCore, QtGui
+        # defer Qt-related imports
+        from sgtk.platform.qt import QtCore, QtGui
 
-    #     # The main widget
-    #     widget = QtGui.QWidget(parent)
-    #     widget_layout = QtGui.QVBoxLayout()
+        # The main widget
+        widget = QtGui.QWidget(parent)
+        widget_layout = QtGui.QVBoxLayout()
 
-    #     # create a group box to display the description
-    #     description_group_box = QtGui.QGroupBox(widget)
-    #     description_group_box.setTitle("Description:")
+        # create a group box to display the description
+        description_group_box = QtGui.QGroupBox(widget)
+        description_group_box.setTitle("Description:")
 
-    #     # Defer setting the description text, this will be updated when
-    #     # the version type combobox value is changed
-    #     description_label = QtGui.QLabel()
-    #     description_label.setWordWrap(True)
-    #     description_label.setOpenExternalLinks(True)
-    #     description_label.setTextFormat(QtCore.Qt.RichText)
+        # Defer setting the description text, this will be updated when
+        # the version type combobox value is changed
+        description_label = QtGui.QLabel()
+        description_label.setWordWrap(True)
+        description_label.setOpenExternalLinks(True)
+        description_label.setTextFormat(QtCore.Qt.RichText)
 
-    #     # create the layout to use within the group box
-    #     description_layout = QtGui.QVBoxLayout()
-    #     description_layout.addWidget(description_label)
-    #     description_layout.addStretch()
-    #     description_group_box.setLayout(description_layout)
+        # create the layout to use within the group box
+        description_layout = QtGui.QVBoxLayout()
+        description_layout.addWidget(description_label)
+        description_layout.addStretch()
+        description_group_box.setLayout(description_layout)
 
-    #     # Add a combobox to edit the version type option
-    #     version_type_combobox = QtGui.QComboBox(widget)
-    #     version_type_combobox.setAccessibleName("Version type selection dropdown")
-    #     version_type_combobox.addItems(self.VERSION_TYPE_OPTIONS)
-    #     # Hook up the signal/slot to update the description according to the current version type
-    #     version_type_combobox.currentIndexChanged.connect(
-    #         lambda index: self._on_version_type_changed(
-    #             version_type_combobox.currentText(), description_label
-    #         )
-    #     )
+        # Add a combobox to edit the version type option
+        version_type_combobox = QtGui.QComboBox(widget)
+        version_type_combobox.setAccessibleName("Version type selection dropdown")
+        version_type_combobox.addItems(self.VERSION_TYPE_OPTIONS)
+        # Hook up the signal/slot to update the description according to the current version type
+        version_type_combobox.currentIndexChanged.connect(
+            lambda index: self._on_version_type_changed(
+                version_type_combobox.currentText(), description_label
+            )
+        )
 
-    #     # Add all the minor widgets to the main widget
-    #     widget_layout.addWidget(description_group_box)
-    #     widget_layout.addWidget(version_type_combobox)
-    #     widget.setLayout(widget_layout)
+        # Add all the minor widgets to the main widget
+        widget_layout.addWidget(description_group_box)
+        widget_layout.addWidget(version_type_combobox)
+        widget.setLayout(widget_layout)
 
-    #     # Set the widget property to store the combobox to access in get_ui_settings and set_ui_settings
-    #     widget.setProperty("description_label", description_label)
-    #     widget.setProperty("version_type_combobox", version_type_combobox)
+        # Set the widget property to store the combobox to access in get_ui_settings and set_ui_settings
+        widget.setProperty("description_label", description_label)
+        widget.setProperty("version_type_combobox", version_type_combobox)
 
-    #     return widget
+        return widget
 
-    # def get_ui_settings(self, widget, items=None):
-    #     """
-    #     This method is required to be defined in order for the custom UI to show up in the app.
+    def get_ui_settings(self, widget, items=None):
+        """
+        This method is required to be defined in order for the custom UI to show up in the app.
 
-    #     Invoked by the Publisher when the selection changes. This method gathers the settings
-    #     on the previously selected task, so that they can be later used to repopulate the
-    #     custom UI if the task gets selected again. They will also be passed to the accept, validate,
-    #     publish and finalize methods, so that the settings can be used to drive the publish process.
+        Invoked by the Publisher when the selection changes. This method gathers the settings
+        on the previously selected task, so that they can be later used to repopulate the
+        custom UI if the task gets selected again. They will also be passed to the accept, validate,
+        publish and finalize methods, so that the settings can be used to drive the publish process.
 
-    #     The widget argument is the widget that was previously created by
-    #     `create_settings_widget`.
+        The widget argument is the widget that was previously created by
+        `create_settings_widget`.
 
-    #     The method returns a dictionary, where the key is the name of a
-    #     setting that should be updated and the value is the new value of that
-    #     setting. Note that it is up to you how you want to store the UI's state as
-    #     settings and you don't have to necessarily to return all the values from
-    #     the UI. This is to allow the publisher to update a subset of settings
-    #     when multiple tasks have been selected.
+        The method returns a dictionary, where the key is the name of a
+        setting that should be updated and the value is the new value of that
+        setting. Note that it is up to you how you want to store the UI's state as
+        settings and you don't have to necessarily to return all the values from
+        the UI. This is to allow the publisher to update a subset of settings
+        when multiple tasks have been selected.
 
-    #     Example::
+        Example::
 
-    #         {
-    #              "setting_a": "/path/to/a/file"
-    #         }
+            {
+                 "setting_a": "/path/to/a/file"
+            }
 
-    #     :param widget: The widget that was created by `create_settings_widget`
-    #     """
+        :param widget: The widget that was created by `create_settings_widget`
+        """
 
-    #     ui_settings = {}
+        ui_settings = {}
 
-    #     # Get the Version Type settings value from the UI combobox
-    #     version_type_combobox = widget.property("version_type_combobox")
-    #     if version_type_combobox:
-    #         version_type_index = version_type_combobox.currentIndex()
-    #         # if version_type_index >= 0 and version_type_index < len(self.VERSION_TYPE_OPTIONS):
-    #         if 0 <= version_type_index < len(self.VERSION_TYPE_OPTIONS):
-    #             self.VERSION_TYPE_OPTIONS[version_type_index]
-    #             ui_settings["Version Type"] = self.VERSION_TYPE_OPTIONS[
-    #                 version_type_index
-    #             ]
-    #         else:
-    #             self.logger.debug(
-    #                 "Invalid Version Type index {}".format(version_type_index)
-    #             )
+        # Get the Version Type settings value from the UI combobox
+        version_type_combobox = widget.property("version_type_combobox")
+        if version_type_combobox:
+            version_type_index = version_type_combobox.currentIndex()
+            # if version_type_index >= 0 and version_type_index < len(self.VERSION_TYPE_OPTIONS):
+            if 0 <= version_type_index < len(self.VERSION_TYPE_OPTIONS):
+                self.VERSION_TYPE_OPTIONS[version_type_index]
+                ui_settings["Version Type"] = self.VERSION_TYPE_OPTIONS[
+                    version_type_index
+                ]
+            else:
+                self.logger.debug(
+                    "Invalid Version Type index {}".format(version_type_index)
+                )
 
-    #     return ui_settings
+        return ui_settings
 
-    # def set_ui_settings(self, widget, settings, items=None):
-    #     """
-    #     This method is required to be defined in order for the custom UI to show up in the app.
+    def set_ui_settings(self, widget, settings, items=None):
+        """
+        This method is required to be defined in order for the custom UI to show up in the app.
 
-    #     Allows the custom UI to populate its fields with the settings from the
-    #     currently selected tasks.
+        Allows the custom UI to populate its fields with the settings from the
+        currently selected tasks.
 
-    #     The widget is the widget created and returned by
-    #     `create_settings_widget`.
+        The widget is the widget created and returned by
+        `create_settings_widget`.
 
-    #     A list of settings dictionaries are supplied representing the current
-    #     values of the settings for selected tasks. The settings dictionaries
-    #     correspond to the dictionaries returned by the settings property of the
-    #     hook.
+        A list of settings dictionaries are supplied representing the current
+        values of the settings for selected tasks. The settings dictionaries
+        correspond to the dictionaries returned by the settings property of the
+        hook.
 
-    #     Example::
+        Example::
 
-    #         settings = [
-    #         {
-    #              "seeting_a": "/path/to/a/file"
-    #              "setting_b": False
-    #         },
-    #         {
-    #              "setting_a": "/path/to/a/file"
-    #              "setting_b": False
-    #         }]
+            settings = [
+            {
+                 "seeting_a": "/path/to/a/file"
+                 "setting_b": False
+            },
+            {
+                 "setting_a": "/path/to/a/file"
+                 "setting_b": False
+            }]
 
-    #     The default values for the settings will be the ones specified in the
-    #     environment file. Each task has its own copy of the settings.
+        The default values for the settings will be the ones specified in the
+        environment file. Each task has its own copy of the settings.
 
-    #     When invoked with multiple settings dictionaries, it is the
-    #     responsibility of the custom UI to decide how to display the
-    #     information. If you do not wish to implement the editing of multiple
-    #     tasks at the same time, you can raise a ``NotImplementedError`` when
-    #     there is more than one item in the list and the publisher will inform
-    #     the user than only one task of that type can be edited at a time.
+        When invoked with multiple settings dictionaries, it is the
+        responsibility of the custom UI to decide how to display the
+        information. If you do not wish to implement the editing of multiple
+        tasks at the same time, you can raise a ``NotImplementedError`` when
+        there is more than one item in the list and the publisher will inform
+        the user than only one task of that type can be edited at a time.
 
-    #     :param widget: The widget that was created by `create_settings_widget`.
-    #     :param settings: a list of dictionaries of settings for each selected
-    #         task.
-    #     :param items: A list of PublishItems the selected publish tasks are parented to.
-    #     """
+        :param widget: The widget that was created by `create_settings_widget`.
+        :param settings: a list of dictionaries of settings for each selected
+            task.
+        :param items: A list of PublishItems the selected publish tasks are parented to.
+        """
 
-    #     if not settings:
-    #         return
+        if not settings:
+            return
 
-    #     if len(settings) > 1:
-    #         raise NotImplementedError
+        if len(settings) > 1:
+            raise NotImplementedError
 
-    #     version_type_combobox = widget.property("version_type_combobox")
-    #     if not version_type_combobox:
-    #         self.logger.debug(
-    #             "Failed to retrieve Version Type combobox to set custom UI"
-    #         )
-    #         return
+        version_type_combobox = widget.property("version_type_combobox")
+        if not version_type_combobox:
+            self.logger.debug(
+                "Failed to retrieve Version Type combobox to set custom UI"
+            )
+            return
 
-    #     description_label = widget.property("description_label")
-    #     if not description_label:
-    #         self.logger.debug(
-    #             "Failed to retrieve Version Type combobox to set custom UI"
-    #         )
+        description_label = widget.property("description_label")
+        if not description_label:
+            self.logger.debug(
+                "Failed to retrieve Version Type combobox to set custom UI"
+            )
 
-    #     # Get the default setting for version type
-    #     default_value = self.settings.get("Version Type", {}).get(
-    #         "default", self.VERSION_TYPE_OPTIONS[0]
-    #     )
+        # Get the default setting for version type
+        default_value = self.settings.get("Version Type", {}).get(
+            "default", self.VERSION_TYPE_OPTIONS[0]
+        )
 
-    #     # Get the version type value from the settings, and set the combobox accordingly
-    #     version_type_value = settings[0].get("Version Type", default_value)
-    #     version_type_index = max(self.VERSION_TYPE_OPTIONS.index(version_type_value), 0)
-    #     # Set the version type combobox
-    #     current_version_index = version_type_combobox.currentIndex()
-    #     if current_version_index == version_type_index:
-    #         # Combobox already has the correct verstion type - manually trigger the 'currentIndexChanged'
-    #         # slot to update the description label based on the version
-    #         self._on_version_type_changed(version_type_value, description_label)
-    #     else:
-    #         version_type_combobox.setCurrentIndex(version_type_index)
+        # Get the version type value from the settings, and set the combobox accordingly
+        version_type_value = settings[0].get("Version Type", default_value)
+        version_type_index = max(self.VERSION_TYPE_OPTIONS.index(version_type_value), 0)
+        # Set the version type combobox
+        current_version_index = version_type_combobox.currentIndex()
+        if current_version_index == version_type_index:
+            # Combobox already has the correct verstion type - manually trigger the 'currentIndexChanged'
+            # slot to update the description label based on the version
+            self._on_version_type_changed(version_type_value, description_label)
+        else:
+            version_type_combobox.setCurrentIndex(version_type_index)
 
-    # def _on_version_type_changed(self, version_type, description_label):
-    #     """
-    #     Slot called when the Version Type combobox selector index changes.
+    def _on_version_type_changed(self, version_type, description_label):
+        """
+        Slot called when the Version Type combobox selector index changes.
 
-    #     Update the description based on the current Version Type.
+        Update the description based on the current Version Type.
 
-    #     :param version_type: The current Version Type.
-    #     :type version_type: str
-    #     :param description_label: The label widget to set the description on
-    #     :type description_label: QLabel
-    #     """
+        :param version_type: The current Version Type.
+        :type version_type: str
+        :param description_label: The label widget to set the description on
+        :type description_label: QLabel
+        """
 
-    #     if not description_label:
-    #         return
+        if not description_label:
+            return
 
-    #     note = ""
-    #     if version_type == self.VERSION_TYPE_3D:
-    #         is_3d_viewer_enabled = self._is_3d_viewer_enabled()
+        note = ""
+        if version_type == self.VERSION_TYPE_3D:
+            is_3d_viewer_enabled = self._is_3d_viewer_enabled()
 
-    #         if is_3d_viewer_enabled is None:
-    #             note = """
-    #                 <br/><br/>
-    #                 <b>NOTE:</b>
-    #                 <br/>
-    #                 <b>
-    #                     Failed to check if 3D Review is enabled for your site.
-    #                 <br/>
-    #                     You may create a 3D Version for review, but if 3D Review is not enabled,
-    #                     you will see an error message 'No web playable media available' when trying to open the Version with the Media viewer.
-    #                 </b>
-    #                 <br/><br/>
-    #                 <b>
-    #                     Please contact Autodesk support to access your site preference for 3D Review or use the 2D Version publish option instead.
-    #                 </b>
-    #             """
-    #         elif not is_3d_viewer_enabled:
-    #             note = """
-    #                 <br/><br/>
-    #                 <b>NOTE:</b>
-    #                 <br/>
-    #                 <b>
-    #                    Your site does not have 3D Review enabled.
-    #                     <br/>
-    #                    You may create a 3D Version for review, but until your site has 3D Review enabled,
-    #                    you will see an error message 'No web playable media available' when trying to open the Version with the Media viewer.
-    #                 </b>
-    #                 <br/><br/>
-    #                 <b>
-    #                     Please contact Autodesk support to have 3D Review enabled on your ShotGrid site or use the 2D Version publish option instead.
-    #                 </b>
-    #             """
+            if is_3d_viewer_enabled is None:
+                note = """
+                    <br/><br/>
+                    <b>NOTE:</b>
+                    <br/>
+                    <b>
+                        Failed to check if 3D Review is enabled for your site.
+                    <br/>
+                        You may create a 3D Version for review, but if 3D Review is not enabled,
+                        you will see an error message 'No web playable media available' when trying to open the Version with the Media viewer.
+                    </b>
+                    <br/><br/>
+                    <b>
+                        Please contact Autodesk support to access your site preference for 3D Review or use the 2D Version publish option instead.
+                    </b>
+                """
+            elif not is_3d_viewer_enabled:
+                note = """
+                    <br/><br/>
+                    <b>NOTE:</b>
+                    <br/>
+                    <b>
+                       Your site does not have 3D Review enabled.
+                        <br/>
+                       You may create a 3D Version for review, but until your site has 3D Review enabled,
+                       you will see an error message 'No web playable media available' when trying to open the Version with the Media viewer.
+                    </b>
+                    <br/><br/>
+                    <b>
+                        Please contact Autodesk support to have 3D Review enabled on your ShotGrid site or use the 2D Version publish option instead.
+                    </b>
+                """
 
-    #     text = "{description}{note}".format(
-    #         description=self.VERSION_TYPE_DESCRIPTIONS.get(
-    #             version_type, self.description
-    #         ),
-    #         note=note,
-    #     )
-    #     description_label.setText(text)
+        text = "{description}{note}".format(
+            description=self.VERSION_TYPE_DESCRIPTIONS.get(
+                version_type, self.description
+            ),
+            note=note,
+        )
+        description_label.setText(text)
 
     ############################################################################
     # Protected functions

--- a/hooks/tk-multi-publish2/basic/upload_session_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_session_version.py
@@ -109,6 +109,43 @@ class UploadVersionPlugin(HookBaseClass):
         """
         return ["vred.session"]
 
+    @property
+    def description(self):
+        """
+        Verbose, multi-line description of what the plugin does (:class:`str`).
+
+        The string can contain html for formatting for display in the UI (any
+        html tags supported by Qt's rich text engine).
+
+        The description is displayed via the plugin's default
+        :meth:`create_settings_widget` implementation, as shown in the image
+        below:
+
+        .. image:: ./resources/plugin_description.png
+
+        |
+
+        A simple implementation example:
+
+        .. code-block:: python
+
+            @property
+            def description(self):
+
+                return '''
+                Creates a publish in Shotgun.
+
+                A <b>Publish</b> entry will be created in Shotgun which will
+                include a reference to the file's path on disk. Other users will
+                be able to access the published file via the
+                <b><a href='%s'>Loader</a></b> so long as they have access to
+                the file's location on disk.
+                ''' % (loader_url,)
+
+        """
+
+        return self.VERSION_TYPE_DESCRIPTIONS[self.VERSION_TYPE_2D]
+
     def accept(self, settings, item):
         """
         Method called by the publisher to determine if an item is of any

--- a/hooks/tk-multi-publish2/basic/upload_session_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_session_version.py
@@ -80,7 +80,7 @@ class UploadVersionPlugin(HookBaseClass):
         upload_version_settings = {
             "Version Type": {
                 "type": "str",
-                "default": self.VERSION_TYPE_OPTIONS[0],
+                "default": self.VERSION_TYPE_2D,
                 "description": "Generate a {options} or {last_option} Version".format(
                     options=", ".join(self.VERSION_TYPE_OPTIONS[:-1]),
                     last_option=self.VERSION_TYPE_OPTIONS[-1],
@@ -263,250 +263,253 @@ class UploadVersionPlugin(HookBaseClass):
 
     ############################################################################
     # Methods for creating/displaying custom plugin interface
+    #
+    # Uncomment this to introduce custom UI to toggle between 2D/3D Version
+    # creation for review
 
-    def create_settings_widget(self, parent, items=None):
-        """
-        Creates a Qt widget, for the supplied parent widget (a container widget
-        on the right side of the publish UI).
+    # def create_settings_widget(self, parent, items=None):
+    #     """
+    #     Creates a Qt widget, for the supplied parent widget (a container widget
+    #     on the right side of the publish UI).
 
-        :param parent: The parent to use for the widget being created.
-        :param items: A list of PublishItems the selected publish tasks are parented to.
-        :return: A QtGui.QWidget or subclass that displays information about
-            the plugin and/or editable widgets for modifying the plugin's
-            settings.
-        """
+    #     :param parent: The parent to use for the widget being created.
+    #     :param items: A list of PublishItems the selected publish tasks are parented to.
+    #     :return: A QtGui.QWidget or subclass that displays information about
+    #         the plugin and/or editable widgets for modifying the plugin's
+    #         settings.
+    #     """
 
-        # defer Qt-related imports
-        from sgtk.platform.qt import QtCore, QtGui
+    #     # defer Qt-related imports
+    #     from sgtk.platform.qt import QtCore, QtGui
 
-        # The main widget
-        widget = QtGui.QWidget(parent)
-        widget_layout = QtGui.QVBoxLayout()
+    #     # The main widget
+    #     widget = QtGui.QWidget(parent)
+    #     widget_layout = QtGui.QVBoxLayout()
 
-        # create a group box to display the description
-        description_group_box = QtGui.QGroupBox(widget)
-        description_group_box.setTitle("Description:")
+    #     # create a group box to display the description
+    #     description_group_box = QtGui.QGroupBox(widget)
+    #     description_group_box.setTitle("Description:")
 
-        # Defer setting the description text, this will be updated when
-        # the version type combobox value is changed
-        description_label = QtGui.QLabel()
-        description_label.setWordWrap(True)
-        description_label.setOpenExternalLinks(True)
-        description_label.setTextFormat(QtCore.Qt.RichText)
+    #     # Defer setting the description text, this will be updated when
+    #     # the version type combobox value is changed
+    #     description_label = QtGui.QLabel()
+    #     description_label.setWordWrap(True)
+    #     description_label.setOpenExternalLinks(True)
+    #     description_label.setTextFormat(QtCore.Qt.RichText)
 
-        # create the layout to use within the group box
-        description_layout = QtGui.QVBoxLayout()
-        description_layout.addWidget(description_label)
-        description_layout.addStretch()
-        description_group_box.setLayout(description_layout)
+    #     # create the layout to use within the group box
+    #     description_layout = QtGui.QVBoxLayout()
+    #     description_layout.addWidget(description_label)
+    #     description_layout.addStretch()
+    #     description_group_box.setLayout(description_layout)
 
-        # Add a combobox to edit the version type option
-        version_type_combobox = QtGui.QComboBox(widget)
-        version_type_combobox.setAccessibleName("Version type selection dropdown")
-        version_type_combobox.addItems(self.VERSION_TYPE_OPTIONS)
-        # Hook up the signal/slot to update the description according to the current version type
-        version_type_combobox.currentIndexChanged.connect(
-            lambda index: self._on_version_type_changed(
-                version_type_combobox.currentText(), description_label
-            )
-        )
+    #     # Add a combobox to edit the version type option
+    #     version_type_combobox = QtGui.QComboBox(widget)
+    #     version_type_combobox.setAccessibleName("Version type selection dropdown")
+    #     version_type_combobox.addItems(self.VERSION_TYPE_OPTIONS)
+    #     # Hook up the signal/slot to update the description according to the current version type
+    #     version_type_combobox.currentIndexChanged.connect(
+    #         lambda index: self._on_version_type_changed(
+    #             version_type_combobox.currentText(), description_label
+    #         )
+    #     )
 
-        # Add all the minor widgets to the main widget
-        widget_layout.addWidget(description_group_box)
-        widget_layout.addWidget(version_type_combobox)
-        widget.setLayout(widget_layout)
+    #     # Add all the minor widgets to the main widget
+    #     widget_layout.addWidget(description_group_box)
+    #     widget_layout.addWidget(version_type_combobox)
+    #     widget.setLayout(widget_layout)
 
-        # Set the widget property to store the combobox to access in get_ui_settings and set_ui_settings
-        widget.setProperty("description_label", description_label)
-        widget.setProperty("version_type_combobox", version_type_combobox)
+    #     # Set the widget property to store the combobox to access in get_ui_settings and set_ui_settings
+    #     widget.setProperty("description_label", description_label)
+    #     widget.setProperty("version_type_combobox", version_type_combobox)
 
-        return widget
+    #     return widget
 
-    def get_ui_settings(self, widget, items=None):
-        """
-        This method is required to be defined in order for the custom UI to show up in the app.
+    # def get_ui_settings(self, widget, items=None):
+    #     """
+    #     This method is required to be defined in order for the custom UI to show up in the app.
 
-        Invoked by the Publisher when the selection changes. This method gathers the settings
-        on the previously selected task, so that they can be later used to repopulate the
-        custom UI if the task gets selected again. They will also be passed to the accept, validate,
-        publish and finalize methods, so that the settings can be used to drive the publish process.
+    #     Invoked by the Publisher when the selection changes. This method gathers the settings
+    #     on the previously selected task, so that they can be later used to repopulate the
+    #     custom UI if the task gets selected again. They will also be passed to the accept, validate,
+    #     publish and finalize methods, so that the settings can be used to drive the publish process.
 
-        The widget argument is the widget that was previously created by
-        `create_settings_widget`.
+    #     The widget argument is the widget that was previously created by
+    #     `create_settings_widget`.
 
-        The method returns a dictionary, where the key is the name of a
-        setting that should be updated and the value is the new value of that
-        setting. Note that it is up to you how you want to store the UI's state as
-        settings and you don't have to necessarily to return all the values from
-        the UI. This is to allow the publisher to update a subset of settings
-        when multiple tasks have been selected.
+    #     The method returns a dictionary, where the key is the name of a
+    #     setting that should be updated and the value is the new value of that
+    #     setting. Note that it is up to you how you want to store the UI's state as
+    #     settings and you don't have to necessarily to return all the values from
+    #     the UI. This is to allow the publisher to update a subset of settings
+    #     when multiple tasks have been selected.
 
-        Example::
+    #     Example::
 
-            {
-                 "setting_a": "/path/to/a/file"
-            }
+    #         {
+    #              "setting_a": "/path/to/a/file"
+    #         }
 
-        :param widget: The widget that was created by `create_settings_widget`
-        """
+    #     :param widget: The widget that was created by `create_settings_widget`
+    #     """
 
-        ui_settings = {}
+    #     ui_settings = {}
 
-        # Get the Version Type settings value from the UI combobox
-        version_type_combobox = widget.property("version_type_combobox")
-        if version_type_combobox:
-            version_type_index = version_type_combobox.currentIndex()
-            # if version_type_index >= 0 and version_type_index < len(self.VERSION_TYPE_OPTIONS):
-            if 0 <= version_type_index < len(self.VERSION_TYPE_OPTIONS):
-                self.VERSION_TYPE_OPTIONS[version_type_index]
-                ui_settings["Version Type"] = self.VERSION_TYPE_OPTIONS[
-                    version_type_index
-                ]
-            else:
-                self.logger.debug(
-                    "Invalid Version Type index {}".format(version_type_index)
-                )
+    #     # Get the Version Type settings value from the UI combobox
+    #     version_type_combobox = widget.property("version_type_combobox")
+    #     if version_type_combobox:
+    #         version_type_index = version_type_combobox.currentIndex()
+    #         # if version_type_index >= 0 and version_type_index < len(self.VERSION_TYPE_OPTIONS):
+    #         if 0 <= version_type_index < len(self.VERSION_TYPE_OPTIONS):
+    #             self.VERSION_TYPE_OPTIONS[version_type_index]
+    #             ui_settings["Version Type"] = self.VERSION_TYPE_OPTIONS[
+    #                 version_type_index
+    #             ]
+    #         else:
+    #             self.logger.debug(
+    #                 "Invalid Version Type index {}".format(version_type_index)
+    #             )
 
-        return ui_settings
+    #     return ui_settings
 
-    def set_ui_settings(self, widget, settings, items=None):
-        """
-        This method is required to be defined in order for the custom UI to show up in the app.
+    # def set_ui_settings(self, widget, settings, items=None):
+    #     """
+    #     This method is required to be defined in order for the custom UI to show up in the app.
 
-        Allows the custom UI to populate its fields with the settings from the
-        currently selected tasks.
+    #     Allows the custom UI to populate its fields with the settings from the
+    #     currently selected tasks.
 
-        The widget is the widget created and returned by
-        `create_settings_widget`.
+    #     The widget is the widget created and returned by
+    #     `create_settings_widget`.
 
-        A list of settings dictionaries are supplied representing the current
-        values of the settings for selected tasks. The settings dictionaries
-        correspond to the dictionaries returned by the settings property of the
-        hook.
+    #     A list of settings dictionaries are supplied representing the current
+    #     values of the settings for selected tasks. The settings dictionaries
+    #     correspond to the dictionaries returned by the settings property of the
+    #     hook.
 
-        Example::
+    #     Example::
 
-            settings = [
-            {
-                 "seeting_a": "/path/to/a/file"
-                 "setting_b": False
-            },
-            {
-                 "setting_a": "/path/to/a/file"
-                 "setting_b": False
-            }]
+    #         settings = [
+    #         {
+    #              "seeting_a": "/path/to/a/file"
+    #              "setting_b": False
+    #         },
+    #         {
+    #              "setting_a": "/path/to/a/file"
+    #              "setting_b": False
+    #         }]
 
-        The default values for the settings will be the ones specified in the
-        environment file. Each task has its own copy of the settings.
+    #     The default values for the settings will be the ones specified in the
+    #     environment file. Each task has its own copy of the settings.
 
-        When invoked with multiple settings dictionaries, it is the
-        responsibility of the custom UI to decide how to display the
-        information. If you do not wish to implement the editing of multiple
-        tasks at the same time, you can raise a ``NotImplementedError`` when
-        there is more than one item in the list and the publisher will inform
-        the user than only one task of that type can be edited at a time.
+    #     When invoked with multiple settings dictionaries, it is the
+    #     responsibility of the custom UI to decide how to display the
+    #     information. If you do not wish to implement the editing of multiple
+    #     tasks at the same time, you can raise a ``NotImplementedError`` when
+    #     there is more than one item in the list and the publisher will inform
+    #     the user than only one task of that type can be edited at a time.
 
-        :param widget: The widget that was created by `create_settings_widget`.
-        :param settings: a list of dictionaries of settings for each selected
-            task.
-        :param items: A list of PublishItems the selected publish tasks are parented to.
-        """
+    #     :param widget: The widget that was created by `create_settings_widget`.
+    #     :param settings: a list of dictionaries of settings for each selected
+    #         task.
+    #     :param items: A list of PublishItems the selected publish tasks are parented to.
+    #     """
 
-        if not settings:
-            return
+    #     if not settings:
+    #         return
 
-        if len(settings) > 1:
-            raise NotImplementedError
+    #     if len(settings) > 1:
+    #         raise NotImplementedError
 
-        version_type_combobox = widget.property("version_type_combobox")
-        if not version_type_combobox:
-            self.logger.debug(
-                "Failed to retrieve Version Type combobox to set custom UI"
-            )
-            return
+    #     version_type_combobox = widget.property("version_type_combobox")
+    #     if not version_type_combobox:
+    #         self.logger.debug(
+    #             "Failed to retrieve Version Type combobox to set custom UI"
+    #         )
+    #         return
 
-        description_label = widget.property("description_label")
-        if not description_label:
-            self.logger.debug(
-                "Failed to retrieve Version Type combobox to set custom UI"
-            )
+    #     description_label = widget.property("description_label")
+    #     if not description_label:
+    #         self.logger.debug(
+    #             "Failed to retrieve Version Type combobox to set custom UI"
+    #         )
 
-        # Get the default setting for version type
-        default_value = self.settings.get("Version Type", {}).get(
-            "default", self.VERSION_TYPE_OPTIONS[0]
-        )
+    #     # Get the default setting for version type
+    #     default_value = self.settings.get("Version Type", {}).get(
+    #         "default", self.VERSION_TYPE_OPTIONS[0]
+    #     )
 
-        # Get the version type value from the settings, and set the combobox accordingly
-        version_type_value = settings[0].get("Version Type", default_value)
-        version_type_index = max(self.VERSION_TYPE_OPTIONS.index(version_type_value), 0)
-        # Set the version type combobox
-        current_version_index = version_type_combobox.currentIndex()
-        if current_version_index == version_type_index:
-            # Combobox already has the correct verstion type - manually trigger the 'currentIndexChanged'
-            # slot to update the description label based on the version
-            self._on_version_type_changed(version_type_value, description_label)
-        else:
-            version_type_combobox.setCurrentIndex(version_type_index)
+    #     # Get the version type value from the settings, and set the combobox accordingly
+    #     version_type_value = settings[0].get("Version Type", default_value)
+    #     version_type_index = max(self.VERSION_TYPE_OPTIONS.index(version_type_value), 0)
+    #     # Set the version type combobox
+    #     current_version_index = version_type_combobox.currentIndex()
+    #     if current_version_index == version_type_index:
+    #         # Combobox already has the correct verstion type - manually trigger the 'currentIndexChanged'
+    #         # slot to update the description label based on the version
+    #         self._on_version_type_changed(version_type_value, description_label)
+    #     else:
+    #         version_type_combobox.setCurrentIndex(version_type_index)
 
-    def _on_version_type_changed(self, version_type, description_label):
-        """
-        Slot called when the Version Type combobox selector index changes.
+    # def _on_version_type_changed(self, version_type, description_label):
+    #     """
+    #     Slot called when the Version Type combobox selector index changes.
 
-        Update the description based on the current Version Type.
+    #     Update the description based on the current Version Type.
 
-        :param version_type: The current Version Type.
-        :type version_type: str
-        :param description_label: The label widget to set the description on
-        :type description_label: QLabel
-        """
+    #     :param version_type: The current Version Type.
+    #     :type version_type: str
+    #     :param description_label: The label widget to set the description on
+    #     :type description_label: QLabel
+    #     """
 
-        if not description_label:
-            return
+    #     if not description_label:
+    #         return
 
-        note = ""
-        if version_type == self.VERSION_TYPE_3D:
-            is_3d_viewer_enabled = self._is_3d_viewer_enabled()
+    #     note = ""
+    #     if version_type == self.VERSION_TYPE_3D:
+    #         is_3d_viewer_enabled = self._is_3d_viewer_enabled()
 
-            if is_3d_viewer_enabled is None:
-                note = """
-                    <br/><br/>
-                    <b>NOTE:</b>
-                    <br/>
-                    <b>
-                        Failed to check if 3D Review is enabled for your site.
-                    <br/>
-                        You may create a 3D Version for review, but if 3D Review is not enabled,
-                        you will see an error message 'No web playable media available' when trying to open the Version with the Media viewer.
-                    </b>
-                    <br/><br/>
-                    <b>
-                        Please contact Autodesk support to access your site preference for 3D Review or use the 2D Version publish option instead.
-                    </b>
-                """
-            elif not is_3d_viewer_enabled:
-                note = """
-                    <br/><br/>
-                    <b>NOTE:</b>
-                    <br/>
-                    <b>
-                       Your site does not have 3D Review enabled.
-                        <br/>
-                       You may create a 3D Version for review, but until your site has 3D Review enabled,
-                       you will see an error message 'No web playable media available' when trying to open the Version with the Media viewer.
-                    </b>
-                    <br/><br/>
-                    <b>
-                        Please contact Autodesk support to have 3D Review enabled on your ShotGrid site or use the 2D Version publish option instead.
-                    </b>
-                """
+    #         if is_3d_viewer_enabled is None:
+    #             note = """
+    #                 <br/><br/>
+    #                 <b>NOTE:</b>
+    #                 <br/>
+    #                 <b>
+    #                     Failed to check if 3D Review is enabled for your site.
+    #                 <br/>
+    #                     You may create a 3D Version for review, but if 3D Review is not enabled,
+    #                     you will see an error message 'No web playable media available' when trying to open the Version with the Media viewer.
+    #                 </b>
+    #                 <br/><br/>
+    #                 <b>
+    #                     Please contact Autodesk support to access your site preference for 3D Review or use the 2D Version publish option instead.
+    #                 </b>
+    #             """
+    #         elif not is_3d_viewer_enabled:
+    #             note = """
+    #                 <br/><br/>
+    #                 <b>NOTE:</b>
+    #                 <br/>
+    #                 <b>
+    #                    Your site does not have 3D Review enabled.
+    #                     <br/>
+    #                    You may create a 3D Version for review, but until your site has 3D Review enabled,
+    #                    you will see an error message 'No web playable media available' when trying to open the Version with the Media viewer.
+    #                 </b>
+    #                 <br/><br/>
+    #                 <b>
+    #                     Please contact Autodesk support to have 3D Review enabled on your ShotGrid site or use the 2D Version publish option instead.
+    #                 </b>
+    #             """
 
-        text = "{description}{note}".format(
-            description=self.VERSION_TYPE_DESCRIPTIONS.get(
-                version_type, self.description
-            ),
-            note=note,
-        )
-        description_label.setText(text)
+    #     text = "{description}{note}".format(
+    #         description=self.VERSION_TYPE_DESCRIPTIONS.get(
+    #             version_type, self.description
+    #         ),
+    #         note=note,
+    #     )
+    #     description_label.setText(text)
 
     ############################################################################
     # Protected functions


### PR DESCRIPTION
* Allow the config option for `3D Version` to be editable from the publish plugin UI
* Replace `3D Version` boolean config setting with `Version Type` string config setting, where Version Type is just the default value (e.g. 2D Version or 3D Version) and this option is then editable via the UI