### PR TITLE
SHOT-3907: Run ShotGrid Python Console at startup

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -154,7 +154,7 @@ class VREDEngine(sgtk.platform.Engine):
         self._dock_widgets.clear()
         self._tabbed_dock_widgets.clear()
 
-        # Close all Shotgun app dialogs that are still opened since
+        # Close all ShotGrid app dialogs that are still opened since
         # some apps do threads cleanup in their onClose event handler
         # Note that this function is called when the engine is restarted (through "Reload Engine and Apps")
 

--- a/engine.py
+++ b/engine.py
@@ -46,6 +46,7 @@ class VREDEngine(sgtk.platform.Engine):
         self._menu_generator = None
         self.vred_version = None
         self._dock_widgets = {}
+        self._tabbed_dock_widgets = {}
 
         super(VREDEngine, self).__init__(tk, context, engine_instance_name, env)
 
@@ -151,6 +152,7 @@ class VREDEngine(sgtk.platform.Engine):
             widget.deleteLater()
             widget = None
         self._dock_widgets.clear()
+        self._tabbed_dock_widgets.clear()
 
         # Close all Shotgun app dialogs that are still opened since
         # some apps do threads cleanup in their onClose event handler
@@ -571,7 +573,8 @@ class VREDEngine(sgtk.platform.Engine):
 
         :returns: the created widget_class instance
         """
-        from sgtk.platform.qt import QtGui
+
+        from sgtk.platform.qt import QtCore, QtGui
 
         self.logger.debug("Begin showing panel {}".format(panel_id))
 
@@ -601,7 +604,12 @@ class VREDEngine(sgtk.platform.Engine):
                 title, bundle, widget_class, *args, **kwargs
             )
 
-        self.show_dock_widget(panel_id, title, widget_instance)
+        dock_properties = self.get_setting("docked_apps", {}).get(bundle.name, {})
+        dock_area = dock_properties.get("pos", None)
+        tabbed = dock_properties.get("tabbed", False)
+        self.show_dock_widget(
+            panel_id, title, widget_instance, dock_area=dock_area, tabbed=tabbed
+        )
 
         # Return the widget created by the method, _create_dialog_with_widget, since this will
         # have the widget_class type expected by the caller. This widget represents the panel
@@ -609,7 +617,7 @@ class VREDEngine(sgtk.platform.Engine):
         widget_instance.setObjectName(panel_id)
         return widget_instance
 
-    def show_dock_widget(self, panel_id, title, widget, dock_area=None):
+    def show_dock_widget(self, panel_id, title, widget, dock_area=None, tabbed=False):
         """
         Create a dock widget managed by the VRED engine, if one has not yet been created. Set the
         widget to show in the dock widget and add it to the VRED dock area.
@@ -621,6 +629,15 @@ class VREDEngine(sgtk.platform.Engine):
 
         dock_widget = self._dock_widgets.get(panel_id, None)
 
+        tabify_widget = None
+        if tabbed:
+            # This dock widget is tabbed, find the (if any) existing docked widgets
+            # in the dock_area to tabify (e.g. add to same dock area and toggle
+            # between widgets with tab bar).
+            tabbed_widets_in_pos = self._tabbed_dock_widgets.get(dock_area, [])
+            if tabbed_widets_in_pos:
+                tabify_widget = tabbed_widets_in_pos[-1]
+
         if dock_widget is None:
             dock_widget = self._tk_vred.DockWidget(
                 title,
@@ -630,12 +647,20 @@ class VREDEngine(sgtk.platform.Engine):
                 self.menu_generator.root_menu
                 is not None,  # closable if there is a menu to reopen it
                 dock_area,
+                tabbed,
             )
             dock_widget.setMinimumWidth(400)
-            self._dock_widgets[panel_id] = dock_widget
 
+            # Keep track of the dock widget
+            self._dock_widgets[panel_id] = dock_widget
+            # If the dock widget is tabbed, keep track of it by dock position in order
+            # to tabify with other dock widgets
+            if tabbed:
+                self._tabbed_dock_widgets.setdefault(dock_area, []).append(dock_widget)
+
+            dock_widget.dock_to_parent(tabify_widget)
         else:
-            dock_widget.reinitialize(title, widget)
+            dock_widget.reinitialize(title, widget, tabify_widget)
 
         dock_widget.show()
 

--- a/info.yml
+++ b/info.yml
@@ -53,6 +53,17 @@ configuration:
         default_value: [ VRED Scene, Alias File, Catpart File, Jt File, Igs File ]
         description: "A list of PublishedFileTypes that are allowed for review with VRED."
 
+    docked_apps:
+        description: "Specify (docking related) properties for docked Apps. This is a dictionary where
+                      each key is the name of the Toolkit App (e.g. tk-multi-shotunpanel) and values
+                      are a dictionary with two keys: 'pos' and 'tabbed'. The 'pos' value is a str, and
+                      must be one of: 'left', 'right', 'top', 'bottom', which indicates the dock area
+                      for the App. The 'tabbed' value is a bool, which indicates whether the docked App
+                      should be tabified with other docked widgets or not."
+        allows_empty: True
+        type: dict
+        default_value: {}
+
 
 # the ShotGrid fields that this engine needs in order to operate correctly
 requires_shotgun_fields:

--- a/python/tk_vred/dock_widget.py
+++ b/python/tk_vred/dock_widget.py
@@ -120,18 +120,28 @@ class DockWidget(QtGui.QDockWidget):
             event.ignore()
             self.setFloating(False)
 
-    def reinitialize(self, title, widget, dock_with_widget=None):
+    def reinitialize(self, title, widget, tabify_widget=None):
         """
         Re-set the title and child widget, and add the dock widget to the main window.
+
+        :param title: the title to display on the dock widget
+        :type title: str
+        :param widget: the widget to set for this dock widget
+        :type widget: QtGui.QWidget
+        :param tabify_widget: (optional) the widget to put in a tab group with this dock widget
+        :type tabify_widget: DockWidget
         """
 
         self.setWindowTitle(title)
         self.setWidget(widget)
-        self.dock_to_parent(dock_with_widget)
+        self.dock_to_parent(tabify_widget)
 
     def dock_to_parent(self, tabify_widget=None):
         """
         Convenience method to dock the widget to its parent widget.
+
+        :param tabify_widget: (optional) the widget to put in a tab group with this dock widget
+        :type tabify_widget: DockWidget
         """
 
         if tabify_widget and self.tabbed:

--- a/python/tk_vred/menu_generation.py
+++ b/python/tk_vred/menu_generation.py
@@ -138,14 +138,19 @@ class VREDMenuGenerator(object):
 
     def clean_menu(self):
         """
-        Remove ShotGrid root menu in VRED, if it exists.
+        Remove ShotGrid root menu in VRED, if it exists and
+        clear the menu_favourites property.
         """
 
         if self._root_menu is not None:
-            self._engine.logger.debug("{}: Clean up menu".format(self))
+            self._engine.logger.debug("{}: Clean up root menu".format(self))
 
             self._root_menu.clean()
             self._root_menu = None
+
+        if self._menu_favourites is not None:
+            self._engine.logger.debug("{}: Clean up favourites menu".format(self))
+            self._menu_favourites = None
 
     def _create_context_menu(self):
         """


### PR DESCRIPTION
* Add docked_app settings to specify docking related properties for App widgets
* By default, dock ShotGrid Panel on the right, and dock ShotGrid Python Console on the right in a tabbed group
* Update VREDEngine and DockWidget class to 'tabify' docked widgets