### PR TITLE
SHOT-4311: Improve thumbnails on publish

### DIFF
--- a/hooks/tk-multi-publish2/basic/collector.py
+++ b/hooks/tk-multi-publish2/basic/collector.py
@@ -259,7 +259,9 @@ class VREDSessionCollector(HookBaseClass):
         except Exception as e:
             self.logger.error(f"Failed to set default thumbnail: {e}")
         finally:
-            if thumbnail_path and os.path.exists(thumbnail_path):
+            try:
                 os.remove(thumbnail_path)
+            except:
+                pass
 
         return pixmap

--- a/hooks/tk-multi-publish2/basic/collector.py
+++ b/hooks/tk-multi-publish2/basic/collector.py
@@ -15,7 +15,6 @@ import tempfile
 import sgtk
 from sgtk.platform.qt import QtGui
 
-import vrFileIO
 import vrRenderSettings
 
 HookBaseClass = sgtk.get_hook_baseclass()
@@ -110,7 +109,7 @@ class VREDSessionCollector(HookBaseClass):
             parent_item.properties["bg_processing"] = bg_processing.value
 
         # get the path to the current file
-        path = vrFileIO.getFileIOFilePath()
+        path = self.vredpy.vrFileIO.getFileIOFilePath()
 
         # determine the display name for the item
         if path:
@@ -164,7 +163,7 @@ class VREDSessionCollector(HookBaseClass):
         :return:
         """
 
-        render_path = vrRenderSettings.getRenderFilename()
+        render_path = self.vredpy.vrRenderSettings.getRenderFilename()
         render_folder = os.path.dirname(render_path)
 
         if not os.path.isdir(render_folder):

--- a/hooks/tk-multi-publish2/basic/collector.py
+++ b/hooks/tk-multi-publish2/basic/collector.py
@@ -74,7 +74,7 @@ class VREDSessionCollector(HookBaseClass):
 
     @property
     def vredpy(self):
-        """Get the VREDPy api module."""
+        """Get the VRED api module."""
         return self.parent.engine.vredpy
 
     def process_current_session(self, settings, parent_item):
@@ -239,10 +239,10 @@ class VREDSessionCollector(HookBaseClass):
 
     def _get_thumbnail_pixmap(self):
         """
-        Generate a thumbnail from the VRED viewport as the default thumbnail.
+        Generate a thumbnail from the current VRED viewport.
 
-        :return: The file path to the thumbnail.
-        :rtype: str
+        :return: A thumbnail of the current VRED viewport.
+        :rtype: QtGui.QPixmap
         """
 
         pixmap = None

--- a/hooks/tk-multi-publish2/basic/upload_session_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_session_version.py
@@ -243,16 +243,6 @@ class UploadVersionPlugin(HookBaseClass):
                     f"Uploaded Version media from path {uploaded_movie_path}"
                 )
 
-            if thumbnail_path:
-                self.parent.shotgun.upload_thumbnail(
-                    entity_type=version_type,
-                    entity_id=version_id,
-                    path=thumbnail_path,
-                )
-                self.logger.info(
-                    f"Uploaded Version thumbnail from path {thumbnail_path}"
-                )
-
             # Remove the temporary directory or files created to generate media content
             self._cleanup_temp_files(media_package_path)
 

--- a/hooks/tk-multi-publish2/basic/upload_session_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_session_version.py
@@ -381,7 +381,6 @@ class UploadVersionPlugin(HookBaseClass):
         version_type_combobox = widget.property("version_type_combobox")
         if version_type_combobox:
             version_type_index = version_type_combobox.currentIndex()
-            # if version_type_index >= 0 and version_type_index < len(self.VERSION_TYPE_OPTIONS):
             if 0 <= version_type_index < len(self.VERSION_TYPE_OPTIONS):
                 self.VERSION_TYPE_OPTIONS[version_type_index]
                 ui_settings["Version Type"] = self.VERSION_TYPE_OPTIONS[

--- a/hooks/tk-multi-publish2/basic/upload_session_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_session_version.py
@@ -216,7 +216,9 @@ class UploadVersionPlugin(HookBaseClass):
             if version_media_type == self.VERSION_TYPE_3D:
                 # Pass the thumbnail retrieved to override the LMV thumbnail, and ignore the
                 # LMV thumbnail output
-                media_package_path, _, _ = self._translate_file_to_lmv(item, thumbnail_path=thumbnail_path)
+                media_package_path, _, _ = self._translate_file_to_lmv(
+                    item, thumbnail_path=thumbnail_path
+                )
                 self.logger.info("Translated file to LMV")
 
             if media_package_path:
@@ -527,8 +529,8 @@ class UploadVersionPlugin(HookBaseClass):
         Remove any temporary directories or files from the given path.
 
         If `remove_from_root` is True, the top most level directory of the given path is
-        used to remove all sub directories and files.        
-        
+        used to remove all sub directories and files.
+
         :param path: The file path to remove temporary files and/or directories from.
         :type path: str
         :param remove_from_root: True will remove directories and files from the top most level
@@ -548,17 +550,14 @@ class UploadVersionPlugin(HookBaseClass):
             # Get the top most level of the path that is inside the root temp dir
             relative_path = os.path.relpath(path, tempdir)
             path = os.path.normpath(
-                os.path.join(
-                    tempdir,
-                    relative_path.split(os.path.sep)[0]
-                )
+                os.path.join(tempdir, relative_path.split(os.path.sep)[0])
             )
 
         if os.path.isdir(path):
             shutil.rmtree(path)
         elif os.path.isfile(path):
             os.remove(path)
-        
+
     def _translate_file_to_lmv(self, item, thumbnail_path=None):
         """
         Translate the current Alias file as an LMV package in order to upload it to ShotGrid as a 3D Version

--- a/hooks/tk-multi-publish2/basic/upload_session_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_session_version.py
@@ -201,7 +201,7 @@ class UploadVersionPlugin(HookBaseClass):
             # be sure to strip the extension from the publish name
             path_components = publisher.util.get_file_path_components(path)
             filename = path_components["filename"]
-            (publish_name, extension) = os.path.splitext(filename)
+            (publish_name, _) = os.path.splitext(filename)
             item.properties["publish_name"] = publish_name
 
             # create the Version in Shotgun

--- a/hooks/tk-multi-publish2/basic/upload_session_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_session_version.py
@@ -233,6 +233,8 @@ class UploadVersionPlugin(HookBaseClass):
 
             uploaded_movie_path = media_package_path or thumbnail_path
             if uploaded_movie_path:
+                # Uplod to the `sg_uploaded_movie` field on the Version so that the Version
+                # thumbnail shows the "play" button on hover from ShotGrid Web
                 self.parent.shotgun.upload(
                     entity_type=version_type,
                     entity_id=version_id,

--- a/python/tk_vred/vred_py/vred_py.py
+++ b/python/tk_vred/vred_py/vred_py.py
@@ -92,7 +92,9 @@ class VREDPy:
                 patched_attr = None
 
             if patched_attr is None:
-                raise self.VREDPyNotSupportedError(
+                # hasattr call this method and expects AttributeError to be raised when the
+                # attribute is not found.
+                raise AttributeError(
                     f"This VRED version does not support the API attribute: {name}"
                 )
 


### PR DESCRIPTION
* Set the publish default thumbnail to the current VRED viewport and show it in the publish screenshot widget UI
* Allow user to override default thumbnail by using screen grab widget
* Do not use thumbnails generated by LMV