### PR TITLE
SHOT-4317: Update for 2024.2

### DIFF
--- a/plugins/Shotgun/vrShotgun.py
+++ b/plugins/Shotgun/vrShotgun.py
@@ -1,6 +1,10 @@
 import os
 
-from PySide2 import QtCore, QtGui
+try:
+    from PySide2 import QtCore, QtGui
+except ModuleNotFoundError:
+    from PySide6 import QtCore, QtGui
+
 import uiTools
 
 import sgtk

--- a/plugins/Shotgun/vrShotgun.py
+++ b/plugins/Shotgun/vrShotgun.py
@@ -1,6 +1,3 @@
-# For Python2 integer division
-from __future__ import division
-
 import os
 
 from PySide2 import QtCore, QtGui


### PR DESCRIPTION
* VRED 2024.2 no longer ships with PySide2, only PySide6
* VRED 2024 up to the .2 release ships both PySide2 and PySide6