### PR TITLE
Add tk-framework-lmv requirement.

### DIFF
--- a/hooks/tk-multi-publish2/basic/upload_session_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_session_version.py
@@ -180,13 +180,13 @@ class UploadVersionPlugin(HookBaseClass):
 
             framework_lmv = self.load_framework("tk-framework-lmv_v1.x.x")
             if not framework_lmv:
-                self.logger.error(
-                    "Missing required framework tk-framework-lmv v1.x.x"
-                )
+                self.logger.error("Missing required framework tk-framework-lmv v1.x.x")
                 return False
 
             translator = framework_lmv.import_module("translator")
-            lmv_translator = translator.LMVTranslator(path, self.parent.sgtk, item.context)
+            lmv_translator = translator.LMVTranslator(
+                path, self.parent.sgtk, item.context
+            )
             lmv_translator_path = lmv_translator.get_translator_path()
             if not lmv_translator_path:
                 self.logger.error(

--- a/hooks/tk-multi-publish2/basic/upload_session_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_session_version.py
@@ -178,7 +178,7 @@ class UploadVersionPlugin(HookBaseClass):
                     "Please contact Autodesk support to have 3D Review enabled on your ShotGrid site or use the 2D Version publish option instead."
                 )
 
-        framework_lmv = self.load_framework("tk-framework-lmv_v0.x.x")
+        framework_lmv = self.load_framework("tk-framework-lmv_v1.x.x")
         if not framework_lmv:
             self.logger.error("Could not run LMV translation: missing ATF framework")
             return False
@@ -590,7 +590,7 @@ class UploadVersionPlugin(HookBaseClass):
         path = item.get_property("path")
 
         # Translate file to LMV
-        framework_lmv = self.load_framework("tk-framework-lmv_v0.x.x")
+        framework_lmv = self.load_framework("tk-framework-lmv_v1.x.x")
         translator = framework_lmv.import_module("translator")
         lmv_translator = translator.LMVTranslator(path, self.parent.sgtk, item.context)
         lmv_translator.translate()

--- a/hooks/tk-multi-publish2/basic/upload_session_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_session_version.py
@@ -180,7 +180,7 @@ class UploadVersionPlugin(HookBaseClass):
 
         framework_lmv = self.load_framework("tk-framework-lmv_v1.x.x")
         if not framework_lmv:
-            self.logger.error("Could not run LMV translation: missing ATF framework")
+            self.logger.error("Failed to load required framework tk-framework-lmv verison 1.x.x")
             return False
 
         translator = framework_lmv.import_module("translator")

--- a/hooks/tk-multi-publish2/basic/upload_session_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_session_version.py
@@ -178,21 +178,21 @@ class UploadVersionPlugin(HookBaseClass):
                     "Please contact Autodesk support to have 3D Review enabled on your ShotGrid site or use the 2D Version publish option instead."
                 )
 
-        framework_lmv = self.load_framework("tk-framework-lmv_v1.x.x")
-        if not framework_lmv:
-            self.logger.error(
-                "Failed to load required framework tk-framework-lmv verison 1.x.x"
-            )
-            return False
+            framework_lmv = self.load_framework("tk-framework-lmv_v1.x.x")
+            if not framework_lmv:
+                self.logger.error(
+                    "Missing required framework tk-framework-lmv v1.x.x"
+                )
+                return False
 
-        translator = framework_lmv.import_module("translator")
-        lmv_translator = translator.LMVTranslator(path, self.parent.sgtk, item.context)
-        lmv_translator_path = lmv_translator.get_translator_path()
-        if not lmv_translator_path:
-            self.logger.error(
-                "Missing translator for VRED. VRED must be installed locally to run LMV translation."
-            )
-            return False
+            translator = framework_lmv.import_module("translator")
+            lmv_translator = translator.LMVTranslator(path, self.parent.sgtk, item.context)
+            lmv_translator_path = lmv_translator.get_translator_path()
+            if not lmv_translator_path:
+                self.logger.error(
+                    "Missing translator for VRED. VRED must be installed locally to run LMV translation."
+                )
+                return False
 
         return True
 

--- a/hooks/tk-multi-publish2/basic/upload_session_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_session_version.py
@@ -180,7 +180,9 @@ class UploadVersionPlugin(HookBaseClass):
 
         framework_lmv = self.load_framework("tk-framework-lmv_v1.x.x")
         if not framework_lmv:
-            self.logger.error("Failed to load required framework tk-framework-lmv verison 1.x.x")
+            self.logger.error(
+                "Failed to load required framework tk-framework-lmv verison 1.x.x"
+            )
             return False
 
         translator = framework_lmv.import_module("translator")

--- a/info.yml
+++ b/info.yml
@@ -75,3 +75,6 @@ description: "ShotGrid Integration for VRED"
 # Required minimum versions for this item to run
 requires_shotgun_version:
 requires_core_version: "v0.19.18"
+
+frameworks:
+  - {"name": "tk-framework-lmv", "version": "v1.x.x"}


### PR DESCRIPTION
* Requires v1.x.x for breaking change in lmv framework to remove executables
* Only validate the framework exists when performing 3D publish (2D does not use the framework and so not required)