### PR TITLE
SHOT-4311: Include thumbnail in LMV package

### DIFF
--- a/hooks/tk-multi-publish2/basic/upload_session_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_session_version.py
@@ -590,6 +590,7 @@ class UploadVersionPlugin(HookBaseClass):
         """
 
         path = item.get_property("path")
+        thumbnail_path = item.get_thumbnail_as_path()
 
         # Translate file to LMV
         framework_lmv = self.load_framework("tk-framework-lmv_v1.x.x")
@@ -600,7 +601,8 @@ class UploadVersionPlugin(HookBaseClass):
         # Package up the LMV files into a zip file
         file_name = str(item.properties["sg_version_data"]["id"])
         package_path, lmv_thumbnail_path = lmv_translator.package(
-            svf_file_name=file_name
+            svf_file_name=file_name,
+            thumbnail_path=thumbnail_path,
         )
 
         return package_path, lmv_thumbnail_path, lmv_translator.output_directory


### PR DESCRIPTION
* Must include thumbnail image in LMV package for ShotGrid to use this image as the Version thumbnail