### PR TITLE
SHOT-4351: Fix plugin for VRED Design

### DIFF
--- a/plugins/Shotgun/vrShotgun.py
+++ b/plugins/Shotgun/vrShotgun.py
@@ -46,6 +46,7 @@ class vrShotgun(vrShotgun_form, vrShotgun_base):
                 showImportOptions=False,
             )
 
+
 def onDestroyVREDScriptPlugin():
     """
     This method is called before this VRED plugin is destroyed.

--- a/plugins/Shotgun/vrShotgun.py
+++ b/plugins/Shotgun/vrShotgun.py
@@ -1,10 +1,11 @@
 # Cannot use sgtk.platform.qt as it is not initialized at this point
 try:
-    from PySide2 import QtCore, QtWidgets
+    from PySide2 import QtCore
 except ModuleNotFoundError:
-    from PySide6 import QtCore, QtWidgets
+    from PySide6 import QtCore
 
 import os
+import uiTools
 import sgtk
 import vrFileIO
 import vrScenegraph
@@ -12,16 +13,19 @@ import vrScenegraph
 
 sgtk.LogManager().initialize_base_file_handler("tk-vred")
 logger = sgtk.LogManager.get_logger(__name__)
-flow_production_tracking_plugin = None
+vrShotgun_form, vrShotgun_base = uiTools.loadUiType("vrShotgunGUI.ui")
+shotgun = None
 
 
-class vrFlowProductionTrackingPlugin(QtCore.QObject):
+class vrShotgun(vrShotgun_form, vrShotgun_base):
     """Class object to create a Scripts Plugin in VRED."""
 
     def __init__(self, parent=None):
         """Initialize the plugin."""
-        super(vrFlowProductionTrackingPlugin, self).__init__(parent)
-        QtCore.QTimer.singleShot(1, self.init)
+        super(vrShotgun, self).__init__(parent)
+        parent.layout().addWidget(self)
+        self.setupUi(self)
+        QtCore.QTimer.singleShot(0, self.init)
 
     def __del__(self):
         """Clean up the plugin."""
@@ -42,7 +46,6 @@ class vrFlowProductionTrackingPlugin(QtCore.QObject):
                 showImportOptions=False,
             )
 
-
 def onDestroyVREDScriptPlugin():
     """
     This method is called before this VRED plugin is destroyed.
@@ -60,11 +63,6 @@ def onDestroyVREDScriptPlugin():
 # Create the VRED plugin
 try:
     if os.getenv("SHOTGUN_ENABLE") == "1":
-        flow_production_tracking_plugin = vrFlowProductionTrackingPlugin()
-        label = QtWidgets.QLabel(VREDPluginWidget)
-        label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
-        label.setScaledContents(True)
-        label.setText("Flow Production Tracking menu installed in main menu bar.")
-        VREDPluginWidget.layout().addWidget(label)
+        shotgun = vrShotgun(VREDPluginWidget)
 except Exception as e:
     logger.exception(e)

--- a/plugins/Shotgun/vrShotgun.py
+++ b/plugins/Shotgun/vrShotgun.py
@@ -18,7 +18,14 @@ shotgun = None
 
 
 class vrShotgun(vrShotgun_form, vrShotgun_base):
-    """Class object to create a Scripts Plugin in VRED."""
+    """
+    Class object to create a Scripts Plugin in VRED.
+
+    IMPORTANT: For VRED Design, a special exception is made for the "Shotgun"
+    plugin to run (custom scripts plugins are not supported). So this plugin
+    file must be named "vrShotgun.py" with the class name "vrShotgun", and the
+    plugin must be created from the UI file "vrShotgunGUI.ui".
+    """
 
     def __init__(self, parent=None):
         """Initialize the plugin."""

--- a/plugins/Shotgun/vrShotgunGUI.ui
+++ b/plugins/Shotgun/vrShotgunGUI.ui
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>vrShotgunGUI</class>
+ <widget class="QWidget" name="vrShotgunGUI">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>520</width>
+    <height>364</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>520</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>520</width>
+    <height>16777215</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Flow Production Tracking</string>
+  </property>
+  <property name="autoFillBackground">
+   <bool>false</bool>
+  </property>
+  <property name="styleSheet">
+   <string notr="true"/>
+  </property>
+  <property name="group" stdset="0">
+   <string>Scripts</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QVBoxLayout" name="main_vlayout">
+     <property name="spacing">
+      <number>10</number>
+     </property>
+     <property name="sizeConstraint">
+      <enum>QLayout::SetDefaultConstraint</enum>
+     </property>
+     <property name="leftMargin">
+      <number>5</number>
+     </property>
+     <property name="topMargin">
+      <number>5</number>
+     </property>
+     <property name="rightMargin">
+      <number>5</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item alignment="Qt::AlignTop">
+      <widget class="QLabel" name="description">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Flow Production Tracking (formerly Shotgun) installed in the menu bar.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
* Unfortunately VRED Design requires the plugin file to be named 'vrShotgun' and initialize the plugin using a .UI file
* Revert rebrand changes to keep old Shotgun naming - the engine will take care of displaying Flow Production Tracking (where it can)