### PR TITLE
SHOT-4386: Update min supported logic to avoid dialog pop up

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -138,10 +138,11 @@ class VREDEngine(sgtk.platform.Engine):
 
         # check for version compatibility
         self.vred_version = os.getenv("TK_VRED_VERSION", None)
+        vred_major_version = self.vred_version[:4]
         self.logger.debug("Running VRED version {}".format(self.vred_version))
         if (
             self._version_check(
-                self.vred_version,
+                vred_major_version,
                 str(self.get_setting("compatibility_dialog_min_version")),
             )
             > 0
@@ -160,7 +161,7 @@ class VREDEngine(sgtk.platform.Engine):
                     "Warning - Flow Production Tracking Toolkit!",
                     msg,
                 )
-        elif self._version_check(self.vred_version, "2021.0") < 0 and self.get_setting(
+        elif self._version_check(vred_major_version, "2021.0") < 0 and self.get_setting(
             "compatibility_dialog_old_version"
         ):
             msg = (

--- a/info.yml
+++ b/info.yml
@@ -39,7 +39,7 @@ configuration:
         description:    "Specify the minimum Application major version that will prompt a warning if
                         it isn't yet fully supported and tested with Toolkit.  To disable the warning
                         dialog for the version you are testing, it is recommended that you set this
-                        value to the current major version + 1."
+                        value to the latest supported version."
         default_value:  2025
 
     compatibility_dialog_old_version:


### PR DESCRIPTION
* Logic now will only check the major version for minimum version - this means that if we define the config setting to `2025` for the `compatibility_dialog_min_version` then all 2025.x.x versions will not trigger this warning dialog