### PR TITLE
SHOT-4411: Background Publishing is now handled by the Publish App as a UI option

### DIFF
--- a/hooks/tk-multi-publish2/basic/collector.py
+++ b/hooks/tk-multi-publish2/basic/collector.py
@@ -60,11 +60,6 @@ class VREDSessionCollector(HookBaseClass):
                 "to publish plugins via the collected item's "
                 "properties. ",
             },
-            "Background Processing": {
-                "type": "bool",
-                "default": False,
-                "description": "Boolean to turn on/off the background publishing process.",
-            },
         }
 
         # update the base settings with these settings
@@ -102,11 +97,6 @@ class VREDSessionCollector(HookBaseClass):
         """
 
         publisher = self.parent
-
-        # store the Batch Processing settings in the root item properties
-        bg_processing = settings.get("Background Processing")
-        if bg_processing:
-            parent_item.properties["bg_processing"] = bg_processing.value
 
         # get the path to the current file
         path = self.vredpy.vrFileIO.getFileIOFilePath()


### PR DESCRIPTION
* The publish app provides an option in the UI to turn on/off bg publishing
* The publish app will handle setting the bg processing flag on the publish tree root item

**Requires: https://github.com/shotgunsoftware/tk-multi-publish2/pull/198**